### PR TITLE
Robust re-connection logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,19 @@ module.exports = function () {
       client.connect(player.host, function (err) {
         if (err) return cb(err)
         player.emit('connect')
-        client.launch(castv2.DefaultMediaReceiver, function (err, p) {
+
+        client.getSessions(function (err, sess) {
+          if (err) return cb(err)
+
+          var session = sess[0]
+          if (session && session.appId === castv2.DefaultMediaReceiver.APP_ID) {
+            client.join(session, castv2.DefaultMediaReceiver, ready)
+          } else {
+            client.launch(castv2.DefaultMediaReceiver, ready)
+          }
+        })
+
+        function ready (err, p) {
           if (err) return cb(err)
 
           player.emit('ready')
@@ -75,7 +87,7 @@ module.exports = function () {
           })
 
           cb(null, p)
-        })
+        }
       })
     })
 
@@ -187,7 +199,7 @@ module.exports = function () {
         }, cb)
       })
     }
-    
+
     player.volume = function (vol, cb) {
       if (!cb) cb = noop
       connect(function (err, p) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromecasts",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Query your local network for Chromecasts and have them play media",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Simply initializing a new media receiver doesn't work as a proper re-connect logic, because the new one doesn't carry the state we're expecting, and we fall out of sync. 
 
This fixes it by taking an active media receiver session and re-uses it.

This is a huge fix from my POV, because my Chromecast disconnects me after a few minutes of inactivity on pause. This is a terrible UX, since after then we always end up with some sort of uncaught exception and we can't use the chromecast anymore. If we don't re-connect, we get castv2 emitting errors because the sockets are closed and null-ed, if we do, then we get a 'cannot read .mediaSessionId of undefined' - the expected session state can't be retrieved.

But I'll need someone else to verify it everything is working OK for them.

Also, I've purposefully used only the first session, because I don't really know what multiple sessions mean on a chromecast :) 

Some of my references
https://github.com/thibauts/node-castv2-client/issues/42
https://gist.github.com/Vaporexpress/9dd4beefef290cb54801
