### PR TITLE
Replace `request` with `simple-get`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 var castv2 = require('castv2-client')
 var debug = require('debug')('chromecasts')
 var events = require('events')
+var get = require('simple-get')
 var mdns = require('multicast-dns')
 var mime = require('mime')
 var parseString = require('xml2js').parseString
-var request = require('request')
 
 var SSDP
 try {
@@ -262,10 +262,9 @@ module.exports = function () {
     ssdp.on('response', function (headers, statusCode, info) {
       if (!headers.LOCATION) return
 
-      request.get(headers.LOCATION, function (err, res, body) {
+      get.concat(headers.LOCATION, function (err, res, body) {
         if (err) return
-
-        parseString(body, {explicitArray: false, explicitRoot: false},
+        parseString(body.toString(), {explicitArray: false, explicitRoot: false},
           function (err, service) {
             if (err) return
             if (!service.device) return

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "debug": "^2.1.3",
     "mime": "^1.3.4",
     "multicast-dns": "^2.1.0",
-    "request": "^2.55.0",
+    "simple-get": "^2.0.0",
     "thunky": "^0.1.0",
     "xml2js": "^0.4.8"
   },


### PR DESCRIPTION
request has 67 dependencies.
simple-get has 4 dependencies.

Helps make `npm install webtorrent` faster!