### PR TITLE
un-mute on setting volume, in case it was muted

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,7 +211,7 @@ module.exports = function () {
 
         player.request({
           type: 'SET_VOLUME',
-          volume: vol === 0 ? { muted: true } : { level: vol }
+          volume: vol === 0 ? { muted: true } : { level: vol, muted: false }
         }, cb)
       })
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromecasts",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Query your local network for Chromecasts and have them play media",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
For some reason, this is absolutely required on my chromecast to set volume after it's muted

I don't remember that happening before, but it happens now, therefore the PR