### PR TITLE
Allow Custom Sub Styling

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,7 +150,10 @@ module.exports = function () {
         var autoSubtitles = opts.autoSubtitles
         if (autoSubtitles === false) autoSubtitles = 0
         if (autoSubtitles === true) autoSubtitles = 1
-
+        if (opts.subtitles_style) {
+                    media.textTrackStyle = opts.subtitles_style;
+                    this.subtitles_style = opts.subtitles_style;
+        }
         var playerOptions = {
           autoplay: opts.autoPlay !== false,
           currentTime: opts.seek,


### PR DESCRIPTION
Example used on https://github.com/popcorn-official/popcorn-desktop/blob/development/src/app/lib/device/chromecast.js
>    subtitles_style: {
                        backgroundColor: AdvSettings.get('subtitle_decoration') === 'Opaque Background' ? '#000000FF' : '#00000000', // color of background - see http://dev.w3.org/csswg/css-color/#hex-notation
                        foregroundColor: AdvSettings.get('subtitle_color') + 'ff', // color of text - see http://dev.w3.org/csswg/css-color/#hex-notation
                        edgeType: AdvSettings.get('subtitle_decoration') === 'Outline' ? 'OUTLINE' : 'NONE', // border of text - can be: "NONE", "OUTLINE", "DROP_SHADOW", "RAISED", "DEPRESSED"
                        edgeColor: '#000000FF', // color of border - see http://dev.w3.org/csswg/css-color/#hex-notation
                        fontScale: ((parseFloat(AdvSettings.get('subtitle_size')) / 28) * 1.3).toFixed(1), // size of the text - transforms into "font-size: " + (fontScale*100) +"%"
                        fontStyle: 'NORMAL', // can be: "NORMAL", "BOLD", "BOLD_ITALIC", "ITALIC",
                        fontFamily: 'Helvetica',
                        fontGenericFamily: 'SANS_SERIF', // can be: "SANS_SERIF", "MONOSPACED_SANS_SERIF", "SERIF", "MONOSPACED_SERIF", "CASUAL", "CURSIVE", "SMALL_CAPITALS",
                        windowColor: '#00000000', // see http://dev.w3.org/csswg/css-color/#hex-notation
                        windowRoundedCornerRadius: 0, // radius in px
                        windowType: 'NONE' // can be: "NONE", "NORMAL", "ROUNDED_CORNERS"
                    }