### PR TITLE
FIX update on Android TV

### DIFF
--- a/index.js
+++ b/index.js
@@ -240,15 +240,17 @@ module.exports = function () {
   dns.on('response', function (response) {
     response.answers.forEach(function (a) {
       if (a.type === 'PTR' && a.name === '_googlecast._tcp.local') {
-        var name = a.data.replace('._googlecast._tcp.local', '')
-        if (!casts[name]) casts[name] = {name: name, host: null}
+        var name = a.data.replace('._googlecast._tcp.local', '').replace(/.*-/g,'')
+        match = /(.*)-/g.exec(a.data.replace('._googlecast._tcp.local', ''))
+        displayname = match[1]
+        if (!casts[name]) casts[name] = {name: displayname, host: null}
       }
     })
 
     var onanswer = function (a) {
       debug('got answer %j', a)
 
-      var name = a.name.replace('.local', '')
+      var name = a.name.replace('.local', '').replace(/-/g,'')
       if (a.type === 'A' && casts[name] && !casts[name].host) {
         casts[name].host = a.data
         emit(casts[name])


### PR DESCRIPTION
On android TV (and maybe on other devices), the "PTR" name is something like:
(Device name)-(identifier address without -)._googlecast._tcp.local
ex: SHIELD-Android-TV-0123a4856bc7d89012ef345abc6789012._googlecast._tcp.local

And the "A" name is
(identifier address with -).local
ex: 0123a485-6bc7-d890-12ef345abc6789012.local

So I had to keep identifier for casts array key.

I can't test on other devices, so please feel free to correct it for something that work on any devices.

Thank you