### PR TITLE
Fix compatibility with other Chromecast enabled devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "castv2-client": "^1.1.0",
     "debug": "^2.1.3",
+    "dns-txt": "^2.0.2",
     "mime": "^1.3.4",
     "multicast-dns": "^6.0.1",
     "simple-get": "^2.0.0",


### PR DESCRIPTION
This should supersede #28. It changes two things:

* Instead of trying to look up the A record (which has a different name than the PTR data), we just use the PTR data to lookup the same name of the SRV record which has the actual hostname we can connect to. This just uses the names as-is so any Google Cast device should be found.
* I also added the `dns-txt` package to decode the associated `TXT` record to get the friendly name and use that if it exists.

Not sure if there is a better way to handle this. But open to suggestions. I was thinking the `TXT` record could be later expanded to gather all the fields in case they might be useful.