### PR TITLE
Remove manufacturer check

### DIFF
--- a/index.js
+++ b/index.js
@@ -279,7 +279,6 @@ module.exports = function () {
           function (err, service) {
             if (err) return
             if (!service.device) return
-            if (service.device.manufacturer !== 'Google Inc.') return
 
             debug('device %j', service.device)
 


### PR DESCRIPTION
Many devices now come with Chromecast built in but the check for `Google Inc.` prevents those devices from being used. For example Vizio Smartcast televisions.