### PR TITLE
Change temporally multicast-dns dependency to fix to the setMulticastInterface error

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "debug": "^2.1.3",
     "dns-txt": "^2.0.2",
     "mime": "^1.3.4",
-    "multicast-dns": "^7.2.2",
+    "multicast-dns": "git://github.com/webtorrent/multicast-dns.git#fix-setMulticastInterface",
     "simple-get": "^2.0.0",
     "thunky": "^0.1.0",
     "xml2js": "^0.4.8"


### PR DESCRIPTION
So it seems there is still an error in the `setMulticastInterface` error. And it looks like [this PR (mafintosh/multicast-dns#50)](https://github.com/mafintosh/multicast-dns/pull/50) fixes the issue.

This was a problem in [Webtorrent too (webtorrent/webtorrent-desktop#1935)](https://github.com/webtorrent/webtorrent-desktop/issues/1935). So we have made a new repo with the branch that fixes the issue with the above mentioned PR.

Until this issue gets fixed, I think it is fine if we just depend on that PR.